### PR TITLE
feat(SliceGwReconciler): Add PodDisruptionBudget Logic (#308)

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -290,6 +290,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - list
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/controllers/slicegateway/pod_disruption_budget.go
+++ b/controllers/slicegateway/pod_disruption_budget.go
@@ -1,0 +1,61 @@
+package slicegateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubeslice/worker-operator/controllers"
+	webhook "github.com/kubeslice/worker-operator/pkg/webhook/pod"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Default minAvailable value in PodDisruptionBudget
+var DefaultMinAvailablePodsInPDB = intstr.FromInt(1)
+
+// constructPodDisruptionBudget creates the PodDisruptionBudget's manifest with labels matching the slice gateway pods.
+func constructPodDisruptionBudget(sliceName, sliceGwName string, minAvailable intstr.IntOrString) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-pdb", sliceGwName),
+			Namespace: controllers.ControlPlaneNamespace,
+			Labels: map[string]string{
+				controllers.ApplicationNamespaceSelectorLabelKey: sliceName,
+				controllers.SliceGatewaySelectorLabelKey:         sliceGwName,
+			},
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvailable,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					controllers.ApplicationNamespaceSelectorLabelKey: sliceName,
+					webhook.PodInjectLabelKey:                        "slicegateway",
+					controllers.SliceGatewaySelectorLabelKey:         sliceGwName,
+				},
+			},
+		},
+	}
+}
+
+// listPodDisruptionBudgetForSliceGateway lists the PodDisruptionBudget objects that match the slice gateway pods.
+func listPodDisruptionBudgetForSliceGateway(ctx context.Context, kubeClient client.Client,
+	sliceName, sliceGwName string) ([]policyv1.PodDisruptionBudget, error) {
+	// Options for listing the PDBs that match the slice and slice gateway
+	listOpts := []client.ListOption{
+		client.MatchingLabels(map[string]string{
+			controllers.ApplicationNamespaceSelectorLabelKey: sliceName,
+			controllers.SliceGatewaySelectorLabelKey:         sliceGwName,
+		}),
+		client.InNamespace(controllers.ControlPlaneNamespace),
+	}
+
+	// List PDBs from cluster that match the slice and slice gateway
+	pdbList := policyv1.PodDisruptionBudgetList{}
+	if err := kubeClient.List(ctx, &pdbList, listOpts...); err != nil {
+		return nil, err
+	}
+
+	return pdbList.Items, nil
+}

--- a/controllers/slicegateway/reconciler.go
+++ b/controllers/slicegateway/reconciler.go
@@ -29,6 +29,7 @@ import (
 	webhook "github.com/kubeslice/worker-operator/pkg/webhook/pod"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -78,6 +79,7 @@ type SliceGwReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;
+//+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=list;create;delete
 
 func (r *SliceGwReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var sliceGwNodePorts []int
@@ -490,6 +492,7 @@ func (r *SliceGwReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&kubeslicev1beta1.SliceGateway{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Watches(
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.findSliceGwObjectsToReconcile),


### PR DESCRIPTION
# Description
The `SliceGwReconciler` should handle the lifecycle of `PodDisruptionBudget` objects that match the slice gateway deployments.

Fixes 308

## How Has This Been Tested?

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [x] I have verified the E2E test cases with new code changes.
* [x] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?

```release-note

```
