### PR TITLE
fix(ServiceExport): Reject Conflicting Alias Names for ServiceExport object (#315)

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -28,3 +28,29 @@ webhooks:
     - statefulsets
     - daemonsets
   sideEffects: NoneOnDryRun
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-webhook
+  failurePolicy: Fail
+  name: webhook.kubeslice.io
+  rules:
+  - apiGroups:
+    - networking.kubeslice.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - serviceexports
+  sideEffects: NoneOnDryRun

--- a/controllers/slice/reconciler.go
+++ b/controllers/slice/reconciler.go
@@ -81,6 +81,7 @@ type SliceReconciler struct {
 //+kubebuilder:rbac:groups=networking.istio.io,resources=serviceentries,verbs=get;list;create;update;watch;delete
 //+kubebuilder:rbac:groups=networking.istio.io,resources=virtualservices,verbs=get;list;create;update;watch;delete
 //+kubebuilder:webhook:path=/mutate-webhook,mutating=true,failurePolicy=fail,groups="";apps,resources=pods;deployments;statefulsets;daemonsets,verbs=create;update,versions=v1,name=webhook.kubeslice.io,admissionReviewVersions=v1,sideEffects=NoneOnDryRun
+//+kubebuilder:webhook:path=/validate-webhook,mutating=false,failurePolicy=fail,groups="networking.kubeslice.io",resources=serviceexports,verbs=create;update,versions=v1beta1,name=webhook.kubeslice.io,admissionReviewVersions=v1,sideEffects=NoneOnDryRun
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete

--- a/main.go
+++ b/main.go
@@ -140,6 +140,13 @@ func main() {
 				Decoder:         admission.NewDecoder(mgr.GetScheme()),
 			},
 		})
+		mgr.GetWebhookServer().Register("/validate-webhook", &webhook.Admission{
+			Handler: &podwh.WebhookServer{
+				Client:          mgr.GetClient(),
+				SliceInfoClient: podwh.NewWebhookClient(),
+				Decoder:         admission.NewDecoder(mgr.GetScheme()),
+			},
+		})
 	}
 	if err != nil {
 		setupLog.With("error", err).Error("unable to start manager")

--- a/pkg/webhook/pod/webhook_utils.go
+++ b/pkg/webhook/pod/webhook_utils.go
@@ -2,8 +2,10 @@ package pod
 
 import (
 	"context"
+	"strings"
 
 	"github.com/kubeslice/apis/pkg/controller/v1alpha1"
+	"github.com/kubeslice/worker-operator/api/v1beta1"
 	"github.com/kubeslice/worker-operator/controllers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,6 +33,33 @@ func (w *webhookClient) GetNamespaceLabels(ctx context.Context, client client.Cl
 	}
 	nsLabels := nS.ObjectMeta.GetLabels()
 	return nsLabels, nil
+}
+
+// Fetch all serviceexport objects belonging to the slice
+func (w *webhookClient) GetAllServiceExports(ctx context.Context, c client.Client, slice string) (*v1beta1.ServiceExportList, error) {
+
+	listOpts := []client.ListOption{
+		client.MatchingLabels(map[string]string{
+			controllers.ApplicationNamespaceSelectorLabelKey: slice,
+		},
+		),
+	}
+
+	serviceExportList := &v1beta1.ServiceExportList{}
+	if err := c.List(ctx, serviceExportList, listOpts...); err != nil {
+		log.Info("Failed to get ServiceExportList", "slice", slice)
+		return nil, err
+	}
+	return serviceExportList, nil
+}
+
+func aliasExist(existingAliases []string, newAlias string) bool {
+	for _, alias := range existingAliases {
+		if strings.EqualFold(alias, newAlias) {
+			return true
+		}
+	}
+	return false
 }
 
 func (w *webhookClient) GetSliceOverlayNetworkType(ctx context.Context, client client.Client, sliceName string) (v1alpha1.NetworkType, error) {


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below-mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
--> The validating webhook will validate the ServiceExport object and admission of ServiceExport objects with conflicting alias names will be rejected.

Fixes  <!-- Mention any issues which might be fixed on this PR merge. --> 315

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [x] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```
